### PR TITLE
Add basic Prisma API integration

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const agents = await prisma.agent.findMany();
+  return NextResponse.json(agents);
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const agent = await prisma.agent.create({ data });
+  return NextResponse.json(agent, { status: 201 });
+}
+
+export async function PUT(req: Request) {
+  const data = await req.json();
+  const agent = await prisma.agent.update({ where: { id: data.id }, data });
+  return NextResponse.json(agent);
+}

--- a/app/api/nfts/route.ts
+++ b/app/api/nfts/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const nfts = await prisma.nft.findMany();
+  return NextResponse.json(nfts);
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const nft = await prisma.nft.create({ data });
+  return NextResponse.json(nft, { status: 201 });
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "recharts": "^2.12.7",
     "redux-saga": "^1.3.0",
     "sonner": "^1.5.0",
+    "@prisma/client": "^5.12.1",
+    "prisma": "^5.12.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.3.3",
     "tailwindcss-animate": "^1.0.7",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model NFT {
+  id        Int      @id @default(autoincrement())
+  name      String
+  imageUrl  String
+  price     Float
+  createdAt DateTime @default(now())
+}
+
+model Agent {
+  id         Int      @id @default(autoincrement())
+  name       String
+  profileUrl String
+  link       String
+}

--- a/store/reducers/agentSlice.ts
+++ b/store/reducers/agentSlice.ts
@@ -1,0 +1,56 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AgentType } from '@/types/agent';
+
+interface AgentState {
+  items: AgentType[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: AgentState = {
+  items: [],
+  loading: false,
+  error: null,
+};
+
+const agentSlice = createSlice({
+  name: 'agents',
+  initialState,
+  reducers: {
+    fetchAgents: (state) => {
+      state.loading = true;
+    },
+    fetchAgentsSuccess: (state, action: PayloadAction<AgentType[]>) => {
+      state.items = action.payload;
+      state.loading = false;
+      state.error = null;
+    },
+    fetchAgentsFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+    addAgent: (state, action: PayloadAction<Omit<AgentType, 'id'>>) => {
+      state.loading = true;
+    },
+    addAgentSuccess: (state, action: PayloadAction<AgentType>) => {
+      state.items.push(action.payload);
+      state.loading = false;
+      state.error = null;
+    },
+    addAgentFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  fetchAgents,
+  fetchAgentsSuccess,
+  fetchAgentsFailure,
+  addAgent,
+  addAgentSuccess,
+  addAgentFailure,
+} = agentSlice.actions;
+
+export default agentSlice.reducer;

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -4,6 +4,7 @@ import footerReducer from './footerSlice';
 import categoriesReducer from './categoriesSlice';
 import nftReducer from './nftSlice';
 import accountReducer from './accountSlice';
+import agentReducer from './agentSlice';
 
 const rootReducer = combineReducers({
   header: headerReducer,
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   categories: categoriesReducer,
   nft: nftReducer,
   account: accountReducer,
+  agents: agentReducer,
 });
 
 export default rootReducer;

--- a/store/sagas/agentSaga.ts
+++ b/store/sagas/agentSaga.ts
@@ -1,0 +1,40 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+import {
+  fetchAgents,
+  fetchAgentsSuccess,
+  fetchAgentsFailure,
+  addAgent,
+  addAgentSuccess,
+  addAgentFailure,
+} from '../reducers/agentSlice';
+
+function* fetchAgentsSaga() {
+  try {
+    const res: Response = yield call(fetch, '/api/agents');
+    const data = yield call([res, 'json']);
+    yield put(fetchAgentsSuccess(data));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch agents';
+    yield put(fetchAgentsFailure(message));
+  }
+}
+
+function* addAgentSaga(action: ReturnType<typeof addAgent>) {
+  try {
+    const res: Response = yield call(fetch, '/api/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(action.payload),
+    });
+    const data = yield call([res, 'json']);
+    yield put(addAgentSuccess(data));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to add agent';
+    yield put(addAgentFailure(message));
+  }
+}
+
+export function* watchAgents() {
+  yield takeLatest(fetchAgents.type, fetchAgentsSaga);
+  yield takeLatest(addAgent.type, addAgentSaga);
+}

--- a/store/sagas/index.ts
+++ b/store/sagas/index.ts
@@ -2,11 +2,13 @@ import { all } from 'redux-saga/effects';
 import { watchCategories } from './categoriesSaga';
 import { watchNFTs } from './nftSaga';
 import { watchAccount } from './accountSaga';
+import { watchAgents } from './agentSaga';
 
 export default function* rootSaga() {
   yield all([
     watchCategories(),
     watchNFTs(),
     watchAccount(),
+    watchAgents(),
   ]);
 }

--- a/store/sagas/nftSaga.ts
+++ b/store/sagas/nftSaga.ts
@@ -1,5 +1,4 @@
 import { call, put, takeLatest } from 'redux-saga/effects';
-import { mockNFTs } from '@/lib/mockData';
 import {
   fetchNFTs,
   fetchNFTsSuccess,
@@ -8,12 +7,12 @@ import {
 
 function* fetchNFTsSaga() {
   try {
-    // Simulate API call
-    yield new Promise(resolve => setTimeout(resolve, 1000));
-    yield put(fetchNFTsSuccess(mockNFTs));
+    const res: Response = yield call(fetch, '/api/nfts');
+    const data = yield call([res, 'json']);
+    yield put(fetchNFTsSuccess(data));
   } catch (error: unknown) {
-    const errorMessage = error instanceof Error 
-      ? error.message 
+    const errorMessage = error instanceof Error
+      ? error.message
       : 'An unknown error occurred while fetching NFTs';
     yield put(fetchNFTsFailure(errorMessage));
   }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,0 +1,6 @@
+export interface AgentType {
+  id: number;
+  name: string;
+  profileUrl: string;
+  link: string;
+}


### PR DESCRIPTION
## Summary
- add Prisma schema for NFT and Agent models
- create API routes for creating and listing NFTs and agents
- initialize Prisma client helper
- add Redux slice and saga for managing agents
- modify NFT saga to use the new API
- register agent slice and saga in root store
- add Prisma packages to package.json

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9c442c0832d94551d3eb02ff046