### PR TITLE
Add Prisma backend APIs and sagas

### DIFF
--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const data = await request.json()
+    const agent = await prisma.agent.update({
+      where: { id: Number(params.id) },
+      data: { profileUrl: data.profileUrl },
+    })
+    return NextResponse.json(agent)
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to update agent' }, { status: 500 })
+  }
+}
+

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const agents = await prisma.agent.findMany()
+  return NextResponse.json(agents)
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json()
+    const agent = await prisma.agent.create({ data })
+    return NextResponse.json(agent, { status: 201 })
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to create agent' }, { status: 500 })
+  }
+}
+

--- a/app/api/nfts/route.ts
+++ b/app/api/nfts/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const nfts = await prisma.nft.findMany()
+  return NextResponse.json(nfts)
+}
+

--- a/app/api/nfts/upload/route.ts
+++ b/app/api/nfts/upload/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json()
+    const nft = await prisma.nft.create({ data })
+    return NextResponse.json(nft, { status: 201 })
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to upload NFT' }, { status: 500 })
+  }
+}
+

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient }
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+

--- a/package.json
+++ b/package.json
@@ -73,6 +73,10 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@prisma/client": "^5.9.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,29 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Agent {
+  id         Int    @id @default(autoincrement())
+  name       String
+  profileUrl String @unique
+  image      String?
+  bio        String?
+}
+
+model Nft {
+  id          Int      @id @default(autoincrement())
+  name        String
+  tokenId     String
+  image       String
+  description String?
+  price       Float
+  creator     String
+  owner       String?
+  createdAt   DateTime @default(now())
+}
+

--- a/store/reducers/agentSlice.ts
+++ b/store/reducers/agentSlice.ts
@@ -1,0 +1,60 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AgentType } from '@/types/agent'
+
+interface AgentsState {
+  items: AgentType[]
+  loading: boolean
+  error: string | null
+}
+
+const initialState: AgentsState = {
+  items: [],
+  loading: false,
+  error: null,
+}
+
+const agentSlice = createSlice({
+  name: 'agents',
+  initialState,
+  reducers: {
+    fetchAgents: state => {
+      state.loading = true
+    },
+    fetchAgentsSuccess: (state, action: PayloadAction<AgentType[]>) => {
+      state.items = action.payload
+      state.loading = false
+      state.error = null
+    },
+    fetchAgentsFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false
+      state.error = action.payload
+    },
+    updateAgentProfileUrl: (
+      state,
+      _action: PayloadAction<{ id: number; profileUrl: string }>
+    ) => {
+      state.loading = true
+    },
+    updateAgentProfileUrlSuccess: (state, action: PayloadAction<AgentType>) => {
+      const idx = state.items.findIndex(a => a.id === action.payload.id)
+      if (idx !== -1) state.items[idx] = action.payload
+      state.loading = false
+    },
+    updateAgentProfileUrlFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false
+      state.error = action.payload
+    },
+  },
+})
+
+export const {
+  fetchAgents,
+  fetchAgentsSuccess,
+  fetchAgentsFailure,
+  updateAgentProfileUrl,
+  updateAgentProfileUrlSuccess,
+  updateAgentProfileUrlFailure,
+} = agentSlice.actions
+
+export default agentSlice.reducer
+

--- a/store/reducers/index.ts
+++ b/store/reducers/index.ts
@@ -4,6 +4,7 @@ import footerReducer from './footerSlice';
 import categoriesReducer from './categoriesSlice';
 import nftReducer from './nftSlice';
 import accountReducer from './accountSlice';
+import agentReducer from './agentSlice';
 
 const rootReducer = combineReducers({
   header: headerReducer,
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   categories: categoriesReducer,
   nft: nftReducer,
   account: accountReducer,
+  agents: agentReducer,
 });
 
 export default rootReducer;

--- a/store/reducers/nftSlice.ts
+++ b/store/reducers/nftSlice.ts
@@ -43,6 +43,18 @@ const nftSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+    uploadNFT: (state, _action: PayloadAction<Partial<NFTType>>) => {
+      state.loading = true;
+    },
+    uploadNFTSuccess: (state, action: PayloadAction<NFTType>) => {
+      state.items.unshift(action.payload);
+      state.loading = false;
+      state.error = null;
+    },
+    uploadNFTFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
     setSelectedNFT: (state, action: PayloadAction<NFTType>) => {
       state.selectedNFT = action.payload;
     },
@@ -86,5 +98,8 @@ export const {
   toggleProperty,
   setSearchTerm,
   resetFilters,
+  uploadNFT,
+  uploadNFTSuccess,
+  uploadNFTFailure,
 } = nftSlice.actions;
 export default nftSlice.reducer;

--- a/store/sagas/agentSaga.ts
+++ b/store/sagas/agentSaga.ts
@@ -1,0 +1,44 @@
+import { call, put, takeLatest } from 'redux-saga/effects'
+import {
+  fetchAgents,
+  fetchAgentsSuccess,
+  fetchAgentsFailure,
+  updateAgentProfileUrl,
+  updateAgentProfileUrlSuccess,
+  updateAgentProfileUrlFailure,
+} from '../reducers/agentSlice'
+
+function* fetchAgentsSaga() {
+  try {
+    const res: Response = yield call(fetch, '/api/agents')
+    const data = yield call([res, 'json'])
+    yield put(fetchAgentsSuccess(data))
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to load agents'
+    yield put(fetchAgentsFailure(message))
+  }
+}
+
+function* updateAgentProfileUrlSaga(
+  action: ReturnType<typeof updateAgentProfileUrl>
+) {
+  try {
+    const { id, profileUrl } = action.payload
+    const res: Response = yield call(fetch, `/api/agents/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileUrl }),
+    })
+    const data = yield call([res, 'json'])
+    yield put(updateAgentProfileUrlSuccess(data))
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to update agent'
+    yield put(updateAgentProfileUrlFailure(message))
+  }
+}
+
+export function* watchAgents() {
+  yield takeLatest(fetchAgents.type, fetchAgentsSaga)
+  yield takeLatest(updateAgentProfileUrl.type, updateAgentProfileUrlSaga)
+}
+

--- a/store/sagas/index.ts
+++ b/store/sagas/index.ts
@@ -2,11 +2,13 @@ import { all } from 'redux-saga/effects';
 import { watchCategories } from './categoriesSaga';
 import { watchNFTs } from './nftSaga';
 import { watchAccount } from './accountSaga';
+import { watchAgents } from './agentSaga';
 
 export default function* rootSaga() {
   yield all([
     watchCategories(),
     watchNFTs(),
     watchAccount(),
+    watchAgents(),
   ]);
 }

--- a/store/sagas/nftSaga.ts
+++ b/store/sagas/nftSaga.ts
@@ -1,24 +1,41 @@
 import { call, put, takeLatest } from 'redux-saga/effects';
-import { mockNFTs } from '@/lib/mockData';
 import {
   fetchNFTs,
   fetchNFTsSuccess,
   fetchNFTsFailure,
+  uploadNFT,
+  uploadNFTSuccess,
+  uploadNFTFailure,
 } from '../reducers/nftSlice';
 
 function* fetchNFTsSaga() {
   try {
-    // Simulate API call
-    yield new Promise(resolve => setTimeout(resolve, 1000));
-    yield put(fetchNFTsSuccess(mockNFTs));
+    const res: Response = yield call(fetch, '/api/nfts')
+    const data = yield call([res, 'json'])
+    yield put(fetchNFTsSuccess(data))
   } catch (error: unknown) {
-    const errorMessage = error instanceof Error 
-      ? error.message 
-      : 'An unknown error occurred while fetching NFTs';
-    yield put(fetchNFTsFailure(errorMessage));
+    const errorMessage =
+      error instanceof Error ? error.message : 'An unknown error occurred while fetching NFTs'
+    yield put(fetchNFTsFailure(errorMessage))
+  }
+}
+
+function* uploadNFTSaga(action: ReturnType<typeof uploadNFT>) {
+  try {
+    const res: Response = yield call(fetch, '/api/nfts/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(action.payload),
+    })
+    const data = yield call([res, 'json'])
+    yield put(uploadNFTSuccess(data))
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to upload NFT'
+    yield put(uploadNFTFailure(errorMessage))
   }
 }
 
 export function* watchNFTs() {
-  yield takeLatest(fetchNFTs.type, fetchNFTsSaga);
+  yield takeLatest(fetchNFTs.type, fetchNFTsSaga)
+  yield takeLatest(uploadNFT.type, uploadNFTSaga)
 }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,0 +1,8 @@
+export interface AgentType {
+  id: number
+  name: string
+  profileUrl: string
+  image?: string
+  bio?: string
+}
+


### PR DESCRIPTION
## Summary
- add Prisma schema and client helper
- create API routes for agents and NFTs
- handle agent updates with Redux saga and slice
- support NFT uploads via saga and API
- wire new sagas into store
- declare Agent type
- add prisma packages to dependencies

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_6844ec4d8ab0832db613c02b4c19f3cb