### PR TITLE
docs: add Neon setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to `.env` and replace the value with your Neon connection string
+# Example: "postgresql://USER:PASSWORD@HOST/neondb?sslmode=require"
+DATABASE_URL="postgresql://USER:PASSWORD@HOST/DATABASE?sslmode=require"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Agents on Crypto
+
+This Next.js monorepo includes API routes powered by Prisma and Redux Saga for managing NFTs and agent profiles.
+
+## Features
+
+- **Agents API** `/api/agents` – list or create agents
+- **Agents Update** `/api/agents/[id]` – update agent profile URL
+- **NFT API** `/api/nfts` – list NFTs
+- **NFT Upload** `/api/nfts/upload` – create NFTs
+- **PostgreSQL via Prisma** – database models for `Agent` and `Nft`
+- **Redux Saga** – sagas for fetching agents and NFTs and uploading NFTs
+
+Run `npm run dev` to start the Next.js application.
+
+## Database Setup
+
+1. Sign up for a free account at [Neon](https://neon.tech/) and create a new project.
+2. From the project dashboard, copy the provided connection string (it will look
+   like `postgres://USER:PASSWORD@HOST/dbname?sslmode=require`).
+3. Copy `.env.example` to `.env` in the project root and set `DATABASE_URL` to
+   this connection string.
+4. Run `npx prisma db push` to create the database tables for local development.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 datasource db {
   provider = "postgresql"
+  // The connection URL from your Neon project goes in `.env`
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- use Neon free tier for database setup
- clarify `DATABASE_URL` example for Neon
- mention Neon in Prisma schema comment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844f8b5e41c832d8069a36485f80d6d