### PR TITLE
Update sagas to use API base path

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,23 @@
+# Agents API Reference
+
+This document summarizes the available endpoints for working with agent profiles.
+
+## Endpoints
+
+- `GET /api/agents` – list all agents
+- `POST /api/agents` – create a new agent
+- `PATCH /api/agents/[id]` – update an agent's profile URL
+
+## Agent Object
+
+```json
+{
+  "id": number,
+  "name": string,
+  "profileUrl": string,
+  "image": string | null,
+  "bio": string | null
+}
+```
+
+All fields except `id`, `name`, and `profileUrl` are optional.

--- a/store/sagas/agentSaga.ts
+++ b/store/sagas/agentSaga.ts
@@ -10,7 +10,8 @@ import {
 
 function* fetchAgentsSaga() {
   try {
-    const res: Response = yield call(fetch, '/api/agents')
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/agents`)
     const data = yield call([res, 'json'])
     yield put(fetchAgentsSuccess(data))
   } catch (err: unknown) {
@@ -24,7 +25,8 @@ function* updateAgentProfileUrlSaga(
 ) {
   try {
     const { id, profileUrl } = action.payload
-    const res: Response = yield call(fetch, `/api/agents/${id}`, {
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/agents/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ profileUrl }),

--- a/store/sagas/nftSaga.ts
+++ b/store/sagas/nftSaga.ts
@@ -10,7 +10,8 @@ import {
 
 function* fetchNFTsSaga() {
   try {
-    const res: Response = yield call(fetch, '/api/nfts')
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/nfts`)
     const data = yield call([res, 'json'])
     yield put(fetchNFTsSuccess(data))
   } catch (error: unknown) {
@@ -22,7 +23,8 @@ function* fetchNFTsSaga() {
 
 function* uploadNFTSaga(action: ReturnType<typeof uploadNFT>) {
   try {
-    const res: Response = yield call(fetch, '/api/nfts/upload', {
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/nfts/upload`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(action.payload),


### PR DESCRIPTION
## Summary
- update agent and nft sagas to respect `NEXT_PUBLIC_API_BASE`
- add documentation for agent endpoints

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68459bfc8dc4832d8275b48347a7fcde