### PR TITLE
Persist created NFTs

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -34,9 +34,12 @@ import { mockCategories } from '@/lib/mockData';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
+import { useAppDispatch } from '@/hooks/useAppDispatch';
+import { uploadNFT } from '@/store/reducers/nftSlice';
 
 export default function CreatePage() {
-  const { connected, connectWallet } = useWeb3();
+  const dispatch = useAppDispatch();
+  const { connected, connectWallet, address } = useWeb3();
   const router = useRouter();
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -128,16 +131,25 @@ export default function CreatePage() {
     }
     
     setIsSubmitting(true);
-    
-    // Simulate blockchain interaction for minting
-    setTimeout(() => {
-      toast({
-        title: 'NFT Created!',
-        description: 'Your NFT has been successfully minted',
-      });
-      setIsSubmitting(false);
-      router.push('/profile');
-    }, 2000);
+
+    dispatch(
+      uploadNFT({
+        name: values.name,
+        description: values.description,
+        image: imagePreview,
+        price: Number(values.price),
+        creator: address || '',
+        tokenId: Date.now().toString(),
+      })
+    );
+
+    toast({
+      title: 'NFT Created!',
+      description: 'Your NFT has been successfully minted',
+    });
+
+    setIsSubmitting(false);
+    router.push('/profile');
   };
   
   if (!connected) {

--- a/app/profile/agents/page.tsx
+++ b/app/profile/agents/page.tsx
@@ -1,30 +1,30 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useWeb3 } from '@/context/Web3Context';
 import { NFTGrid } from '@/components/nft/NFTGrid';
 import { Button } from '@/components/ui/button';
 import { Plus } from 'lucide-react';
-import { mockNFTs } from '@/lib/mockData';
 import { Skeleton } from '@/components/ui/skeleton';
 import Link from 'next/link';
-import { NFTType } from '@/types/nft';
+import { useAppDispatch } from '@/hooks/useAppDispatch';
+import { useAppSelector } from '@/hooks/useAppSelector';
+import { fetchNFTs } from '@/store/reducers/nftSlice';
 
 export default function MyAgentsPage() {
   const { address } = useWeb3();
-  const [myNFTs, setMyNFTs] = useState<NFTType[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  
+  const dispatch = useAppDispatch();
+  const { items: nfts, loading } = useAppSelector((state) => state.nft);
+
   useEffect(() => {
-    // Simulate loading owned NFTs
-    setTimeout(() => {
-      // For demo, return some NFTs as owned
-      setMyNFTs(mockNFTs.slice(0, 3));
-      setIsLoading(false);
-    }, 1500);
-  }, [address]);
+    dispatch(fetchNFTs());
+  }, [dispatch]);
+
+  const myNFTs = nfts.filter(
+    nft => nft.creatorAddress === address || nft.creator === address
+  );
   
-  if (isLoading) {
+  if (loading) {
     return (
       <div className="container mx-auto px-4 py-8">
         <div className="flex justify-between items-center mb-8">

--- a/components/profile/CreatedNFTs.tsx
+++ b/components/profile/CreatedNFTs.tsx
@@ -17,7 +17,9 @@ export function CreatedNFTs() {
     dispatch(fetchNFTs());
   }, [dispatch]);
   
-  const createdNFTs = nfts.filter(nft => nft.creatorAddress === address);
+  const createdNFTs = nfts.filter(
+    nft => nft.creatorAddress === address || nft.creator === address
+  );
   
   if (loading) {
     return (

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,23 @@
+# Agents API Reference
+
+This document summarizes the available endpoints for working with agent profiles.
+
+## Endpoints
+
+- `GET /api/agents` – list all agents
+- `POST /api/agents` – create a new agent
+- `PATCH /api/agents/[id]` – update an agent's profile URL
+
+## Agent Object
+
+```json
+{
+  "id": number,
+  "name": string,
+  "profileUrl": string,
+  "image": string | null,
+  "bio": string | null
+}
+```
+
+All fields except `id`, `name`, and `profileUrl` are optional.

--- a/store/sagas/agentSaga.ts
+++ b/store/sagas/agentSaga.ts
@@ -10,7 +10,8 @@ import {
 
 function* fetchAgentsSaga() {
   try {
-    const res: Response = yield call(fetch, '/api/agents')
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/agents`)
     const data = yield call([res, 'json'])
     yield put(fetchAgentsSuccess(data))
   } catch (err: unknown) {
@@ -24,7 +25,8 @@ function* updateAgentProfileUrlSaga(
 ) {
   try {
     const { id, profileUrl } = action.payload
-    const res: Response = yield call(fetch, `/api/agents/${id}`, {
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/agents/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ profileUrl }),

--- a/store/sagas/nftSaga.ts
+++ b/store/sagas/nftSaga.ts
@@ -10,7 +10,8 @@ import {
 
 function* fetchNFTsSaga() {
   try {
-    const res: Response = yield call(fetch, '/api/nfts')
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/nfts`)
     const data = yield call([res, 'json'])
     yield put(fetchNFTsSuccess(data))
   } catch (error: unknown) {
@@ -22,7 +23,8 @@ function* fetchNFTsSaga() {
 
 function* uploadNFTSaga(action: ReturnType<typeof uploadNFT>) {
   try {
-    const res: Response = yield call(fetch, '/api/nfts/upload', {
+    const base = process.env.NEXT_PUBLIC_API_BASE || ''
+    const res: Response = yield call(fetch, `${base}/api/nfts/upload`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(action.payload),


### PR DESCRIPTION
## Summary
- dispatch uploadNFT when submitting create form
- show user-created NFTs based on wallet address
- switch profile agents page to Redux data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68459bfc8dc4832d8275b48347a7fcde