### PR TITLE
Fix NFT upload API

### DIFF
--- a/app/api/nfts/upload/route.ts
+++ b/app/api/nfts/upload/route.ts
@@ -1,12 +1,45 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
+import { z } from 'zod'
+
+const nftSchema = z.object({
+  name: z.string(),
+  tokenId: z.string(),
+  image: z.string(),
+  description: z.string().optional(),
+  price: z.preprocess((val) => Number(val), z.number()),
+  highestBid: z.preprocess((val) => (val === undefined ? undefined : Number(val)), z.number().optional()),
+  creator: z.string(),
+  creatorAddress: z.string(),
+  creatorImage: z.string(),
+  owner: z.string(),
+  ownerAddress: z.string(),
+  contractAddress: z.string(),
+  likes: z.preprocess((val) => Number(val), z.number()),
+  views: z.preprocess((val) => Number(val), z.number()),
+  category: z.string(),
+  verified: z.preprocess((val) => Boolean(val), z.boolean()),
+  level: z.string(),
+  vendor: z.string(),
+  operationCost: z.preprocess((val) => Number(val), z.number()),
+})
 
 export async function POST(request: Request) {
   try {
-    const data = await request.json()
-    const nft = await prisma.nft.create({ data })
+    const body = await request.json()
+    const parsed = nftSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid NFT data', details: parsed.error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    const nft = await prisma.nft.create({ data: parsed.data })
     return NextResponse.json(nft, { status: 201 })
   } catch (err) {
+    console.error('NFT upload error', err)
     return NextResponse.json({ error: 'Failed to upload NFT' }, { status: 500 })
   }
 }

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -147,7 +147,7 @@ export default function CreatePage() {
         dispatch(
             uploadNFT({
                 name: values.name,
-                description: values.description,
+                description: values.description || '',
                 image: imagePreview,
                 price: Number(values.price),
                 tokenId: Date.now().toString(),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Nft {
   name            String
   tokenId         String
   image           String
-  description     String
+  description     String?
   price           Float
   highestBid      Float?      // ← Add this field
   creator         String


### PR DESCRIPTION
## Summary
- validate NFT payload on the upload endpoint
- accept optional description in the Prisma `Nft` model
- ensure description is always sent from the create form

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e720b5f4832d84abb38955389bdf